### PR TITLE
fix hung at crumb when CSRF is disabled

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -1158,6 +1158,8 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
                 throw new UnauthorizedException(crumbProviderUrl);
             } else if(responseCode == 403) {
                 throw new ForbiddenException(crumbProviderUrl);
+            } else if(responseCode == 404) {
+                return null;
             } else {
                 String response = readInputStream(connection);
                 String[] split = response.split(":");


### PR DESCRIPTION
When CSRF is disabled, http call crumb will return 404 in my Jenkins (2.73.1).
So if responseCode equals 404, return null for crumb