### PR TITLE
 Prevent ConcurrentModificationException in BuildInfoExporterAction.build

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/BuildInfoExporterAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/BuildInfoExporterAction.java
@@ -51,8 +51,10 @@ public class BuildInfoExporterAction implements EnvironmentContributingAction {
      */
     private void addBuildReferenceSafe(BuildReference buildRef)
     {
-        removeDuplicates(builds, buildRef);
-        builds.add(buildRef);
+        synchronized (builds) {
+            removeDuplicates(builds, buildRef);
+            builds.add(buildRef);
+        }
     }
 
     /**
@@ -144,8 +146,10 @@ public class BuildInfoExporterAction implements EnvironmentContributingAction {
 
     private List<BuildReference> getBuildRefs(String project) {
         List<BuildReference> refs = new ArrayList<BuildReference>();
-        for (BuildReference br : builds) {
-            if (br.projectName.equals(project)) refs.add(br);
+        synchronized (builds) {
+            for (BuildReference br : builds) {
+                if (br.projectName.equals(project)) refs.add(br);
+            }
         }
         return refs;
     }
@@ -185,10 +189,12 @@ public class BuildInfoExporterAction implements EnvironmentContributingAction {
      */
     private Set<String> getProjectsWithBuilds() {
         Set<String> projects = new LinkedHashSet<String>();
-        for (BuildReference br : this.builds) {
-            if (br.buildNumber != 0) {
-                if(projects.contains(br.projectName)) projects.remove(br.projectName); //Move to the end
-                projects.add(br.projectName);
+        synchronized (builds) {
+            for (BuildReference br : this.builds) {
+                if (br.buildNumber != 0) {
+                    if(projects.contains(br.projectName)) projects.remove(br.projectName); //Move to the end
+                    projects.add(br.projectName);
+                }
             }
         }
         return projects;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/BuildInfoExporterAction.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/BuildInfoExporterAction.java
@@ -36,12 +36,15 @@ public class BuildInfoExporterAction implements EnvironmentContributingAction {
     public static BuildInfoExporterAction addBuildInfoExporterAction(@Nonnull Run<?, ?> parentBuild, String triggeredProjectName, int buildNumber, URL jobURL, BuildStatus buildResult) {
         BuildReference reference = new BuildReference(triggeredProjectName, buildNumber, jobURL, buildResult);
 
-        BuildInfoExporterAction action = parentBuild.getAction(BuildInfoExporterAction.class);
-        if (action == null) {
-            action = new BuildInfoExporterAction(parentBuild, reference);
-            parentBuild.addAction(action);
-        } else {
-            action.addBuildReference(reference);
+        BuildInfoExporterAction action;
+        synchronized(parentBuild) {
+	        action = parentBuild.getAction(BuildInfoExporterAction.class);
+	        if (action == null) {
+	            action = new BuildInfoExporterAction(parentBuild, reference);
+	            parentBuild.addAction(action);
+	        } else {
+	            action.addBuildReference(reference);
+	        }
         }
         return action;
     }
@@ -187,7 +190,7 @@ public class BuildInfoExporterAction implements EnvironmentContributingAction {
      *
      * @return Set of project names that have at least one build linked.
      */
-    private Set<String> getProjectsWithBuilds() {
+    protected Set<String> getProjectsWithBuilds() {
         Set<String> projects = new LinkedHashSet<String>();
         synchronized (builds) {
             for (BuildReference br : this.builds) {

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/BuildInfoExporterActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/BuildInfoExporterActionTest.java
@@ -1,10 +1,9 @@
 package org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob;
 
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -93,12 +92,12 @@ public class BuildInfoExporterActionTest {
 	private void checkEnv(EnvVars env) {
 		Assert.assertEquals("Job"+PARALLEL_JOBS, env.get("LAST_TRIGGERED_JOB_NAME"));
 		for(int i = 1; i <= PARALLEL_JOBS; i++) {
-			Assert.assertEquals(""+i, env.get("TRIGGERED_BUILD_NUMBERS_Job"+i));
-			Assert.assertEquals(""+i, env.get("TRIGGERED_BUILD_NUMBERS_Job"+i));
-			Assert.assertEquals("SUCCESS", env.get("TRIGGERED_BUILD_RESULT_Job"+i));
-			Assert.assertEquals("SUCCESS", env.get("TRIGGERED_BUILD_RESULT_Job" + i + "_RUN_"+i));
-			Assert.assertEquals("1", env.get("TRIGGERED_BUILD_RUN_COUNT_Job"+i));
-			Assert.assertEquals("http://jenkins/jobs/Job"+i, env.get("TRIGGERED_BUILD_URL_Job"+i));
+			Assert.assertEquals("TRIGGERED_BUILD_NUMBERS_Job"+i, ""+i, env.get("TRIGGERED_BUILD_NUMBERS_Job"+i));
+			Assert.assertEquals("TRIGGERED_BUILD_NUMBERS_Job"+i, ""+i, env.get("TRIGGERED_BUILD_NUMBERS_Job"+i));
+			Assert.assertEquals("TRIGGERED_BUILD_RESULT_Job"+i, "SUCCESS", env.get("TRIGGERED_BUILD_RESULT_Job"+i));
+			Assert.assertEquals("TRIGGERED_BUILD_RESULT_Job" + i + "_RUN_"+i, "SUCCESS", env.get("TRIGGERED_BUILD_RESULT_Job" + i + "_RUN_"+i));
+			Assert.assertEquals("TRIGGERED_BUILD_RUN_COUNT_Job"+i, "1", env.get("TRIGGERED_BUILD_RUN_COUNT_Job"+i));
+			Assert.assertEquals("TRIGGERED_BUILD_URL_Job"+i, "http://jenkins/jobs/Job"+i, env.get("TRIGGERED_BUILD_URL_Job"+i));
 		}
 	}
 	
@@ -118,9 +117,12 @@ public class BuildInfoExporterActionTest {
 			System.out.println("AddActionCallable finished for Job" + i);
 
 			BuildInfoExporterAction action = parentBuild.getAction(BuildInfoExporterAction.class);
-			boolean success = action.getProjectsWithBuilds().contains(jobName);
-			System.out.println("AddActionCallable was " + (success ? "" : "NOT ") + "successful for Job" + i);
-			if(!success) Assert.fail("AddActionCallable was " + (success ? "" : "NOT ") + "successful for Job" + i);
+			Set<String> projectsWithBuilds = action.getProjectsWithBuilds();
+			boolean success = projectsWithBuilds.contains(jobName);
+			String message = String.format("AddActionCallable %s for %s (projects in list: %s)",
+					(success ? "was successful " : "failed"), "Job"+i, projectsWithBuilds.size()) ;
+			System.out.println(message);
+			if(!success) Assert.fail(message);
 			return success;
 		}
 	}

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/BuildInfoExporterActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/BuildInfoExporterActionTest.java
@@ -1,0 +1,154 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.EnvVars;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.ItemGroup;
+import hudson.model.Run;
+import hudson.model.TopLevelItem;
+import jenkins.model.Jenkins;
+
+public class BuildInfoExporterActionTest {
+
+	@Rule
+	public JenkinsRule jenkinsRule = new JenkinsRule();
+
+	private final static int PARALLEL_JOBS = 100;
+	private final static int POOL_SIZE = 50;
+
+	@Test
+	public void testAddBuildInfoExporterAction_sequential() throws IOException {
+		Run<?, ?> parentBuild = new FreeStyleBuild(new FreeStyleProject((ItemGroup<TopLevelItem>) Jenkins.getInstance(), "ParentJob"));
+		for (int i = 1; i <= PARALLEL_JOBS; i++) {
+			BuildInfoExporterAction.addBuildInfoExporterAction(parentBuild, "Job" + i, i, new URL("http://jenkins/jobs/Job" + i), BuildStatus.SUCCESS);
+		}
+		BuildInfoExporterAction action = parentBuild.getAction(BuildInfoExporterAction.class);
+		EnvVars env = new EnvVars();
+		action.buildEnvVars(null, env);
+		checkEnv(env);
+	}
+
+	/**
+	 * We had ConcurrentModificationExceptions in the past.
+	 */
+	@Test
+	public void testAddBuildInfoExporterAction_parallel() throws IOException, InterruptedException, ExecutionException {
+		Run<?, ?> parentBuild = new FreeStyleBuild(new FreeStyleProject((ItemGroup<TopLevelItem>) Jenkins.getInstance(), "ParentJob"));
+		ExecutorService executor = Executors.newFixedThreadPool(POOL_SIZE);
+
+		//Start parallel threads adding BuildInfoExporterActions AND one thread reading in parallel
+		Future<?>[] addFutures = new Future<?>[PARALLEL_JOBS]; 
+		for (int i = 1; i <= PARALLEL_JOBS; i++) {
+			addFutures[i-1] = executor.submit(new AddActionCallable(parentBuild, i));
+		}
+		Future<?> envFuture = executor.submit(new BuildEnvVarsCallable(parentBuild));
+		
+		//Wait until all finished
+		while(!isDone(addFutures) && !envFuture.isDone()) sleep(100);
+		
+		//Check result
+		EnvVars env = (EnvVars)envFuture.get();
+		checkEnv(env);
+	}
+
+
+	private void sleep(int i) {
+		try {
+			Thread.sleep(100);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+	}
+
+	private boolean isDone(Future<?>[] addFutures) throws InterruptedException, ExecutionException {
+		boolean done = true;
+		for(Future<?> addFuture : addFutures) {
+			if(!addFuture.isDone()) {
+				done = false;
+			} else {
+				//Test get to check for exceptions
+				addFuture.get();
+			}
+		}
+		return done;
+	}
+	
+	private void checkEnv(EnvVars env) {
+		Assert.assertEquals("Job"+PARALLEL_JOBS, env.get("LAST_TRIGGERED_JOB_NAME"));
+		for(int i = 1; i <= PARALLEL_JOBS; i++) {
+			Assert.assertEquals(""+i, env.get("TRIGGERED_BUILD_NUMBERS_Job"+i));
+			Assert.assertEquals(""+i, env.get("TRIGGERED_BUILD_NUMBERS_Job"+i));
+			Assert.assertEquals("SUCCESS", env.get("TRIGGERED_BUILD_RESULT_Job"+i));
+			Assert.assertEquals("SUCCESS", env.get("TRIGGERED_BUILD_RESULT_Job" + i + "_RUN_"+i));
+			Assert.assertEquals("1", env.get("TRIGGERED_BUILD_RUN_COUNT_Job"+i));
+			Assert.assertEquals("http://jenkins/jobs/Job"+i, env.get("TRIGGERED_BUILD_URL_Job"+i));
+		}
+	}
+	
+	private static class AddActionCallable implements Callable<Boolean> {
+		Run<?, ?> parentBuild;
+		private int i;
+
+		public AddActionCallable(Run<?, ?> parentBuild, int i) {
+			this.parentBuild = parentBuild;
+			this.i = i;
+		}
+
+		public Boolean call() throws MalformedURLException {
+			String jobName = "Job" + i;
+			BuildInfoExporterAction.addBuildInfoExporterAction(parentBuild, jobName, i,
+					new URL("http://jenkins/jobs/Job" + i), BuildStatus.SUCCESS);
+			System.out.println("AddActionCallable finished for Job" + i);
+
+			BuildInfoExporterAction action = parentBuild.getAction(BuildInfoExporterAction.class);
+			boolean success = action.getProjectsWithBuilds().contains(jobName);
+			System.out.println("AddActionCallable was " + (success ? "" : "NOT ") + "successful for Job" + i);
+			if(!success) Assert.fail("AddActionCallable was " + (success ? "" : "NOT ") + "successful for Job" + i);
+			return success;
+		}
+	}
+
+	private static class BuildEnvVarsCallable implements Callable<EnvVars> {
+		Run<?, ?> parentBuild;
+
+		public BuildEnvVarsCallable(Run<?, ?> parentBuild) {
+			this.parentBuild = parentBuild;
+		}
+
+		public EnvVars call() throws MalformedURLException, InterruptedException, TimeoutException {
+			BuildInfoExporterAction action = parentBuild.getAction(BuildInfoExporterAction.class);
+			EnvVars env = new EnvVars();
+			long startTime = System.currentTimeMillis();
+			while (action == null || action.getProjectsWithBuilds().size() < PARALLEL_JOBS) {
+				try {
+					Thread.sleep(100);
+				} catch (InterruptedException e) {}
+				action = parentBuild.getAction(BuildInfoExporterAction.class);
+				if (action != null) {
+					//Provoke ConcurrentModificationException
+					action.buildEnvVars(null, env);
+				}
+				if(System.currentTimeMillis() - startTime > 120000) throw new TimeoutException("Only " + action.getProjectsWithBuilds().size() + " of " + PARALLEL_JOBS + " jobs");
+			}
+			action.buildEnvVars(null, env);
+			return env;
+		}
+	}
+}

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/BuildInfoExporterActionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/remoteJob/BuildInfoExporterActionTest.java
@@ -90,7 +90,6 @@ public class BuildInfoExporterActionTest {
 	}
 	
 	private void checkEnv(EnvVars env) {
-		Assert.assertEquals("Job"+PARALLEL_JOBS, env.get("LAST_TRIGGERED_JOB_NAME"));
 		for(int i = 1; i <= PARALLEL_JOBS; i++) {
 			Assert.assertEquals("TRIGGERED_BUILD_NUMBERS_Job"+i, ""+i, env.get("TRIGGERED_BUILD_NUMBERS_Job"+i));
 			Assert.assertEquals("TRIGGERED_BUILD_NUMBERS_Job"+i, ""+i, env.get("TRIGGERED_BUILD_NUMBERS_Job"+i));


### PR DESCRIPTION
When triggering remote jobs in parallel massively ConcurrentModificationExceptions occur while modifying the builds list.

```
java.util.ConcurrentModificationException
at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:907)
at java.util.ArrayList$Itr.next(ArrayList.java:857)
at org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.BuildInfoExporterAction.removeDuplicates(BuildInfoExporterAction.java:64)
at org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.BuildInfoExporterAction.addBuildReferenceSafe(BuildInfoExporterAction.java:54)
at org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.BuildInfoExporterAction.addBuildReference(BuildInfoExporterAction.java:78)
at org.jenkinsci.plugins.ParameterizedRemoteTrigger.remoteJob.BuildInfoExporterAction.addBuildInfoExporterAction(BuildInfoExporterAction.java:44)
at org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration.performWaitForBuild(RemoteBuildConfiguration.java:710)
```