### PR TITLE
Do not modify globally configured RemoteJenkinsServer

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -404,8 +404,13 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
         for (RemoteJenkinsServer host : this.getDescriptor().remoteSites) {
             // if we find a match, then stop looping
             if (displayName.equals(host.getDisplayName())) {
-                server = host;
-                break;
+                try {
+                    server = (RemoteJenkinsServer)host.clone();
+                    break;
+                } catch(CloneNotSupportedException e) {
+                    // Clone is supported by RemoteJenkinsServer
+                    throw new RuntimeException(e);
+                }
             }
         }
         return server;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -28,7 +28,7 @@ import hudson.util.FormValidation;
  * @author Maurice W.
  * 
  */
-public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsServer> {
+public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsServer> implements Cloneable {
 
     /**
      * We need to keep this for compatibility - old config deserialization!
@@ -197,5 +197,55 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
         public static Auth2Descriptor getDefaultAuth2Descriptor() {
             return NoneAuth.DESCRIPTOR;
         }
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        RemoteJenkinsServer clone = new RemoteJenkinsServer();
+        clone.setAddress(address);
+        clone.setAuth2(auth2);
+        clone.setDisplayName(displayName);
+        clone.setHasBuildTokenRootSupport(hasBuildTokenRootSupport);
+        return clone;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((address == null) ? 0 : address.hashCode());
+        result = prime * result + ((auth2 == null) ? 0 : auth2.hashCode());
+        result = prime * result + ((displayName == null) ? 0 : displayName.hashCode());
+        result = prime * result + (hasBuildTokenRootSupport ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (! (obj instanceof RemoteJenkinsServer))
+            return false;
+        RemoteJenkinsServer other = (RemoteJenkinsServer) obj;
+        if (address == null) {
+            if (other.address != null)
+                return false;
+        } else if (!address.equals(other.address))
+            return false;
+        if (auth2 == null) {
+            if (other.auth2 != null)
+                return false;
+        } else if (!auth2.equals(other.auth2))
+            return false;
+        if (displayName == null) {
+            if (other.displayName != null)
+                return false;
+        } else if (!displayName.equals(other.displayName))
+            return false;
+        if (hasBuildTokenRootSupport != other.hasBuildTokenRootSupport)
+            return false;
+        return true;
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServerTest.java
@@ -1,0 +1,23 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+
+public class RemoteJenkinsServerTest {
+
+    @Test
+    public void payAttentionToCloneContract() throws Exception {
+        RemoteJenkinsServer server = new RemoteJenkinsServer();
+        server.setAddress("http://www.example.org:8443");
+        server.setDisplayName("My example server.");
+        server.setHasBuildTokenRootSupport(false);
+
+        Object clone = server.clone();
+
+        assertTrue(clone.equals(server));
+        assertFalse(System.identityHashCode(server) == System.identityHashCode(clone));
+    }
+}


### PR DESCRIPTION
Instance of RemoteJenkinsServer as it is configured globally was modified by the plugin. This was
also visible to others keeping a reference to that server, and of course is was also visible
within the same plugin later on.

Credits to MW who first understood and explain the bug.