### PR TITLE
Do not modify globally configured RemoteJenkinsServer [2]

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -404,8 +404,13 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
         for (RemoteJenkinsServer host : this.getDescriptor().remoteSites) {
             // if we find a match, then stop looping
             if (displayName.equals(host.getDisplayName())) {
-                server = host;
-                break;
+                try {
+                    server = (RemoteJenkinsServer)host.clone();
+                    break;
+                } catch(CloneNotSupportedException e) {
+                    // Clone is supported by RemoteJenkinsServer
+                    throw new RuntimeException(e);
+                }
             }
         }
         return server;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -392,11 +392,11 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
     }
 
     /**
-     * Lookup up a Remote Jenkins Server based on display name
+     * Lookup up the globally configured Remote Jenkins Server based on display name
      *
      * @param displayName
      *            Name of the configuration you are looking for
-     * @return A RemoteJenkinsServer object
+     * @return A deep-copy of the RemoteJenkinsServer object configured globally
      */
     private RemoteJenkinsServer findRemoteHost(String displayName) {
         if(isEmpty(displayName)) return null;
@@ -405,7 +405,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
             // if we find a match, then stop looping
             if (displayName.equals(host.getDisplayName())) {
                 try {
-                    server = (RemoteJenkinsServer)host.clone();
+                    server = host.clone();
                     break;
                 } catch(CloneNotSupportedException e) {
                     // Clone is supported by RemoteJenkinsServer

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -28,7 +28,7 @@ import hudson.util.FormValidation;
  * @author Maurice W.
  * 
  */
-public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsServer> {
+public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsServer> implements Cloneable {
 
     /**
      * We need to keep this for compatibility - old config deserialization!
@@ -197,5 +197,55 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
         public static Auth2Descriptor getDefaultAuth2Descriptor() {
             return NoneAuth.DESCRIPTOR;
         }
+    }
+
+    @Override
+    public Object clone() throws CloneNotSupportedException {
+        RemoteJenkinsServer clone = new RemoteJenkinsServer();
+        clone.setAddress(address);
+        clone.setAuth2(auth2);
+        clone.setDisplayName(displayName);
+        clone.setHasBuildTokenRootSupport(hasBuildTokenRootSupport);
+        return clone;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((address == null) ? 0 : address.hashCode());
+        result = prime * result + ((auth2 == null) ? 0 : auth2.hashCode());
+        result = prime * result + ((displayName == null) ? 0 : displayName.hashCode());
+        result = prime * result + (hasBuildTokenRootSupport ? 1231 : 1237);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (! (obj instanceof RemoteJenkinsServer))
+            return false;
+        RemoteJenkinsServer other = (RemoteJenkinsServer) obj;
+        if (address == null) {
+            if (other.address != null)
+                return false;
+        } else if (!address.equals(other.address))
+            return false;
+        if (auth2 == null) {
+            if (other.auth2 != null)
+                return false;
+        } else if (!auth2.equals(other.auth2))
+            return false;
+        if (displayName == null) {
+            if (other.displayName != null)
+                return false;
+        } else if (!displayName.equals(other.displayName))
+            return false;
+        if (hasBuildTokenRootSupport != other.hasBuildTokenRootSupport)
+            return false;
+        return true;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -200,12 +200,12 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
     }
 
     @Override
-    public Object clone() throws CloneNotSupportedException {
+    public RemoteJenkinsServer clone() throws CloneNotSupportedException {
         RemoteJenkinsServer clone = new RemoteJenkinsServer();
-        clone.setAddress(address);
-        clone.setAuth2(auth2);
-        clone.setDisplayName(displayName);
-        clone.setHasBuildTokenRootSupport(hasBuildTokenRootSupport);
+        clone.address = address;
+        clone.auth2 = auth2.clone();
+        clone.displayName = displayName;
+        clone.hasBuildTokenRootSupport = hasBuildTokenRootSupport;
         return clone;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import java.net.URLConnection;
 
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteJenkinsServer;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.exceptions.CredentialsNotFoundException;
 
 import hudson.DescriptorExtensionList;
@@ -13,7 +14,7 @@ import hudson.model.Descriptor;
 import hudson.model.Item;
 import jenkins.model.Jenkins;
 
-public abstract class Auth2 extends AbstractDescribableImpl<Auth2> implements Serializable {
+public abstract class Auth2 extends AbstractDescribableImpl<Auth2> implements Serializable, Cloneable {
 
     private static final long serialVersionUID = -3217381962636283564L;
 
@@ -81,5 +82,15 @@ public abstract class Auth2 extends AbstractDescribableImpl<Auth2> implements Se
      * @return a string representing the authorization.
      */
     public abstract String toString(Item item);
+
+
+    @Override
+    public abstract Auth2 clone() throws CloneNotSupportedException;
+
+    @Override
+    public abstract int hashCode();
+
+    @Override
+    public abstract boolean equals(Object obj);
 
 }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2.java
@@ -5,7 +5,6 @@ import java.io.Serializable;
 import java.net.URLConnection;
 
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.BuildContext;
-import org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteJenkinsServer;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.exceptions.CredentialsNotFoundException;
 
 import hudson.DescriptorExtensionList;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
@@ -161,4 +161,38 @@ public class CredentialsAuth extends Auth2 {
         }
     }
 
+    
+    
+	@Override
+	public Auth2 clone() throws CloneNotSupportedException {
+		CredentialsAuth clone = new CredentialsAuth();
+		clone.credentials = credentials;
+		return clone;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((credentials == null) ? 0 : credentials.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CredentialsAuth other = (CredentialsAuth) obj;
+		if (credentials == null) {
+			if (other.credentials != null)
+				return false;
+		} else if (!credentials.equals(other.credentials))
+			return false;
+		return true;
+	}
+
 }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
@@ -15,7 +15,6 @@ import org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.Base64Utils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.jelly.ThisTagLibrary;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
@@ -164,7 +164,7 @@ public class CredentialsAuth extends Auth2 {
     
     
 	@Override
-	public Auth2 clone() throws CloneNotSupportedException {
+	public CredentialsAuth clone() throws CloneNotSupportedException {
 		CredentialsAuth clone = new CredentialsAuth();
 		clone.credentials = credentials;
 		return clone;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.ParameterizedRemoteTrigger.utils.Base64Utils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.jelly.ThisTagLibrary;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
@@ -184,7 +185,7 @@ public class CredentialsAuth extends Auth2 {
 			return true;
 		if (obj == null)
 			return false;
-		if (getClass() != obj.getClass())
+		if (!this.getClass().isInstance(obj))
 			return false;
 		CredentialsAuth other = (CredentialsAuth) obj;
 		if (credentials == null) {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NoneAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NoneAuth.java
@@ -65,7 +65,7 @@ public class NoneAuth extends Auth2 {
 			return true;
 		if (obj == null)
 			return false;
-		if (getClass() != obj.getClass())
+		if (!this.getClass().isInstance(obj))
 			return false;
 		return true;
 	}	

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NoneAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NoneAuth.java
@@ -49,4 +49,25 @@ public class NoneAuth extends Auth2 {
         }
     }
 
+	@Override
+	public Auth2 clone() throws CloneNotSupportedException {
+		return new NoneAuth();
+	}
+
+	@Override
+	public int hashCode() {
+		return "NoneAuth".hashCode();
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		return true;
+	}	
+
 }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NoneAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NoneAuth.java
@@ -50,7 +50,7 @@ public class NoneAuth extends Auth2 {
     }
 
 	@Override
-	public Auth2 clone() throws CloneNotSupportedException {
+	public NoneAuth clone() throws CloneNotSupportedException {
 		return new NoneAuth();
 	}
 

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
@@ -51,7 +51,7 @@ public class NullAuth extends Auth2 {
 
     
 	@Override
-	public Auth2 clone() throws CloneNotSupportedException {
+	public NullAuth clone() throws CloneNotSupportedException {
 		return new NullAuth();
 	}
 

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
@@ -66,7 +66,7 @@ public class NullAuth extends Auth2 {
 			return true;
 		if (obj == null)
 			return false;
-		if (getClass() != obj.getClass())
+		if (!this.getClass().isInstance(obj))
 			return false;
 		return true;
 	}	

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
@@ -49,4 +49,26 @@ public class NullAuth extends Auth2 {
         }
     }
 
+    
+	@Override
+	public Auth2 clone() throws CloneNotSupportedException {
+		return new NullAuth();
+	}
+
+	@Override
+	public int hashCode() {
+		return "NullAuth".hashCode();
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		return true;
+	}	
+
 }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
@@ -77,4 +77,43 @@ public class TokenAuth extends Auth2 {
         }
     }
 
+	@Override
+	public Auth2 clone() throws CloneNotSupportedException {
+		TokenAuth clone = new TokenAuth();
+		clone.apiToken = apiToken;
+		clone.userName = userName;
+		return clone;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((apiToken == null) ? 0 : apiToken.hashCode());
+		result = prime * result + ((userName == null) ? 0 : userName.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		TokenAuth other = (TokenAuth) obj;
+		if (apiToken == null) {
+			if (other.apiToken != null)
+				return false;
+		} else if (!apiToken.equals(other.apiToken))
+			return false;
+		if (userName == null) {
+			if (other.userName != null)
+				return false;
+		} else if (!userName.equals(other.userName))
+			return false;
+		return true;
+	}
+
 }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
@@ -100,7 +100,7 @@ public class TokenAuth extends Auth2 {
 			return true;
 		if (obj == null)
 			return false;
-		if (getClass() != obj.getClass())
+		if (!this.getClass().isInstance(obj))
 			return false;
 		TokenAuth other = (TokenAuth) obj;
 		if (apiToken == null) {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
@@ -78,7 +78,7 @@ public class TokenAuth extends Auth2 {
     }
 
 	@Override
-	public Auth2 clone() throws CloneNotSupportedException {
+	public TokenAuth clone() throws CloneNotSupportedException {
 		TokenAuth clone = new TokenAuth();
 		clone.apiToken = apiToken;
 		clone.userName = userName;

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServerTest.java
@@ -1,0 +1,23 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+
+public class RemoteJenkinsServerTest {
+
+    @Test
+    public void payAttentionToCloneContract() throws Exception {
+        RemoteJenkinsServer server = new RemoteJenkinsServer();
+        server.setAddress("http://www.example.org:8443");
+        server.setDisplayName("My example server.");
+        server.setHasBuildTokenRootSupport(false);
+
+        Object clone = server.clone();
+
+        assertTrue(clone.equals(server));
+        assertFalse(System.identityHashCode(server) == System.identityHashCode(clone));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServerTest.java
@@ -3,21 +3,86 @@ package org.jenkinsci.plugins.ParameterizedRemoteTrigger;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.CredentialsAuth;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.TokenAuth;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
 import org.junit.Test;
 
 
 public class RemoteJenkinsServerTest {
 
+	private final static String TOKEN = "myToken";
+	private final static String USER = "myUser";
+	private final static String ADDRESS = "http://www.example.org:8443";
+	private final static String DISPLAY_NAME = "My example server.";
+	private final static boolean HAS_BUILD_TOKEN_ROOT_SUPPORT = true;
+		
     @Test
-    public void payAttentionToCloneContract() throws Exception {
+    public void testCloneBehaviour() throws Exception {
+    	TokenAuth auth = new TokenAuth();
+    	auth.setApiToken(TOKEN);
+    	auth.setUserName(USER);
+    	
         RemoteJenkinsServer server = new RemoteJenkinsServer();
-        server.setAddress("http://www.example.org:8443");
-        server.setDisplayName("My example server.");
-        server.setHasBuildTokenRootSupport(false);
+        server.setAddress(ADDRESS);
+        server.setDisplayName(DISPLAY_NAME);
+        server.setAuth2(auth);
+        server.setHasBuildTokenRootSupport(HAS_BUILD_TOKEN_ROOT_SUPPORT);
+        
+        RemoteJenkinsServer clone = server.clone();
 
-        Object clone = server.clone();
-
-        assertTrue(clone.equals(server));
-        assertFalse(System.identityHashCode(server) == System.identityHashCode(clone));
+        //Test if still equal after cloning
+        verifyEqualsHashCode(server, clone);
+        assertEquals("address", ADDRESS, clone.getAddress());
+        assertEquals("address", server.getAddress(), clone.getAddress());
+        assertEquals("remoteAddress", ADDRESS, clone.getRemoteAddress());
+        assertEquals("remoteAddress", server.getRemoteAddress(), clone.getRemoteAddress());
+        assertEquals("auth2", server.getAuth2(), clone.getAuth2());
+        assertEquals("displayName", DISPLAY_NAME, clone.getDisplayName());
+        assertEquals("displayName", server.getDisplayName(), clone.getDisplayName());
+        assertEquals("hasBuildTokenRootSupport", HAS_BUILD_TOKEN_ROOT_SUPPORT, clone.getHasBuildTokenRootSupport());
+        assertEquals("hasBuildTokenRootSupport", server.getHasBuildTokenRootSupport(), clone.getHasBuildTokenRootSupport());
+        
+        //Test if original object affected by clone modifications
+        clone.setAddress("http://www.changed.org:8443");
+        clone.setDisplayName("Changed");
+        clone.setHasBuildTokenRootSupport(false);
+        verifyEqualsHashCode(server, clone, false);
+        assertEquals("address", ADDRESS, server.getAddress());
+        assertEquals("displayName", DISPLAY_NAME, server.getDisplayName());
+        assertEquals("hasBuildTokenRootSupport", HAS_BUILD_TOKEN_ROOT_SUPPORT, server.getHasBuildTokenRootSupport());
+        
+        //Test if clone is deep-copy or if server fields can be modified
+        TokenAuth cloneAuth = (TokenAuth)clone.getAuth2();
+        cloneAuth.setApiToken("changed");
+        cloneAuth.setUserName("changed");
+        TokenAuth serverAuth = (TokenAuth)server.getAuth2();
+        assertEquals("auth.apiToken", TOKEN, serverAuth.getApiToken());
+        assertEquals("auth.userName", USER, serverAuth.getUserName());
+        
+        //Test if clone.setAuth() affects original object
+        CredentialsAuth credAuth = new CredentialsAuth();
+        clone.setAuth2(credAuth);
+        assertEquals("auth", auth, server.getAuth2());
     }
+
+	private void verifyEqualsHashCode(RemoteJenkinsServer server, RemoteJenkinsServer clone) throws CloneNotSupportedException {
+		verifyEqualsHashCode(server, clone, true);
+	}
+
+	private void verifyEqualsHashCode(RemoteJenkinsServer server, RemoteJenkinsServer clone, boolean expectToBeSame) throws CloneNotSupportedException {
+        assertNotEquals("Still same object after clone", System.identityHashCode(server), System.identityHashCode(clone));
+        if(expectToBeSame) {
+    		assertTrue("clone not equals() server", clone.equals(server));
+            assertEquals("clone has different hashCode() than server", server.hashCode(), clone.hashCode());
+        } else {
+    		assertFalse("clone still equals() server", clone.equals(server));
+            assertNotEquals("clone still has same hashCode() than server", server.hashCode(), clone.hashCode());
+        }
+	}
+
 }

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2Test.java
@@ -1,0 +1,72 @@
+package org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class Auth2Test {
+
+	@Test
+	public void testCredentialsAuthCloneBehaviour() throws CloneNotSupportedException {
+		CredentialsAuth original = new CredentialsAuth();
+		original.setCredentials("original");
+		CredentialsAuth clone = original.clone();
+		verifyEqualsHashCode(original, clone);
+		
+		//Test changing clone
+		clone.setCredentials("changed");
+		verifyEqualsHashCode(original, clone, false);
+		assertEquals("original", original.getCredentials());
+		assertEquals("changed", clone.getCredentials());
+	}
+
+	@Test
+	public void testTokenAuthCloneBehaviour() throws CloneNotSupportedException {
+		TokenAuth original = new TokenAuth();
+		original.setApiToken("original");
+		original.setUserName("original");
+		TokenAuth clone = original.clone();
+		verifyEqualsHashCode(original, clone);
+		
+		//Test changing clone
+		clone.setApiToken("changed");
+		clone.setUserName("changed");
+		verifyEqualsHashCode(original, clone, false);
+		assertEquals("original", original.getApiToken());
+		assertEquals("original", original.getUserName());
+		assertEquals("changed", clone.getApiToken());
+		assertEquals("changed", clone.getUserName());
+	}
+
+	@Test
+	public void testNullAuthCloneBehaviour() throws CloneNotSupportedException {
+		NullAuth original = new NullAuth();
+		NullAuth clone = original.clone();
+		verifyEqualsHashCode(original, clone);
+	}
+
+	@Test
+	public void testNoneAuthCloneBehaviour() throws CloneNotSupportedException {
+		NoneAuth original = new NoneAuth();
+		NoneAuth clone = original.clone();
+		verifyEqualsHashCode(original, clone);
+	}
+
+	private void verifyEqualsHashCode(Auth2 original, Auth2 clone) throws CloneNotSupportedException {
+		verifyEqualsHashCode(original, clone, true);
+	}
+
+	private void verifyEqualsHashCode(Auth2 server, Auth2 clone, boolean expectToBeSame) throws CloneNotSupportedException {
+        assertNotEquals("Still same object after clone", System.identityHashCode(server), System.identityHashCode(clone));
+        if(expectToBeSame) {
+    		assertTrue("clone not equals() server", clone.equals(server));
+            assertEquals("clone has different hashCode() than server", server.hashCode(), clone.hashCode());
+        } else {
+    		assertFalse("clone still equals() server", clone.equals(server));
+            assertNotEquals("clone still has same hashCode() than server", server.hashCode(), clone.hashCode());
+        }
+	}
+}

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2Test.java
@@ -59,14 +59,14 @@ public class Auth2Test {
 		verifyEqualsHashCode(original, clone, true);
 	}
 
-	private void verifyEqualsHashCode(Auth2 server, Auth2 clone, boolean expectToBeSame) throws CloneNotSupportedException {
-        assertNotEquals("Still same object after clone", System.identityHashCode(server), System.identityHashCode(clone));
+	private void verifyEqualsHashCode(Auth2 original, Auth2 clone, boolean expectToBeSame) throws CloneNotSupportedException {
+        assertNotEquals("Still same object after clone", System.identityHashCode(original), System.identityHashCode(clone));
         if(expectToBeSame) {
-    		assertTrue("clone not equals() server", clone.equals(server));
-            assertEquals("clone has different hashCode() than server", server.hashCode(), clone.hashCode());
+    		assertTrue("clone not equals() original", clone.equals(original));
+            assertEquals("clone has different hashCode() than original", original.hashCode(), clone.hashCode());
         } else {
-    		assertFalse("clone still equals() server", clone.equals(server));
-            assertNotEquals("clone still has same hashCode() than server", server.hashCode(), clone.hashCode());
+    		assertFalse("clone still equals() original", clone.equals(original));
+            assertNotEquals("clone still has same hashCode() than original", original.hashCode(), clone.hashCode());
         }
 	}
 }


### PR DESCRIPTION
Followup for https://github.com/sap-production/parameterized-remote-trigger-plugin/pull/7

Instance of RemoteJenkinsServer as it is configured globally was modified by the plugin. This was
also visible to others keeping a reference to that server, and of course is was also visible
within the same plugin later on.

Credits to MW who first understood and explain the bug.