### PR TITLE
Switched Auth compatibility to readResolve()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
        <plugin>
          <groupId>org.jenkins-ci.tools</groupId>
          <artifactId>maven-hpi-plugin</artifactId>
+         <extensions>true</extensions>
          <!--  https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions -->
          <configuration>
            <compatibleSinceVersion>3.0.0-SNAPSHOT</compatibleSinceVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
        <plugin>
          <groupId>org.jenkins-ci.tools</groupId>
          <artifactId>maven-hpi-plugin</artifactId>
-         <extensions>true</extensions>
          <!--  https://wiki.jenkins-ci.org/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions -->
          <configuration>
            <compatibleSinceVersion>3.0.0-SNAPSHOT</compatibleSinceVersion>

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/Auth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/Auth.java
@@ -39,9 +39,6 @@ public class Auth extends AbstractDescribableImpl<Auth> implements Serializable 
     public static final String  API_TOKEN          = "apiToken";
     public static final String  CREDENTIALS_PLUGIN = "credentialsPlugin";
 
-    private static final Auth2 NONE_AUTH = new NoneAuth();
-    private static final Auth2 NULL_AUTH = new NullAuth();
-
     private final String authType;
     private final String username;
     private final String apiToken;
@@ -181,14 +178,14 @@ public class Auth extends AbstractDescribableImpl<Auth> implements Serializable 
     }
 
     public static Auth2 authToAuth2(List<Auth> oldAuth) {
-        if(oldAuth == null || oldAuth.size() <= 0) return new NullAuth();
+        if(oldAuth == null || oldAuth.size() <= 0) return NullAuth.INSTANCE;
         return authToAuth2(oldAuth.get(0));
     }
 
     public static Auth2 authToAuth2(Auth oldAuth) {
         String authType = oldAuth.getAuthType();
         if (Auth.NONE.equals(authType)) {
-            return NONE_AUTH;
+            return NoneAuth.INSTANCE;
         } else if (Auth.API_TOKEN.equals(authType)) {
             TokenAuth newAuth = new TokenAuth();
             newAuth.setUserName(oldAuth.getUsername());
@@ -199,7 +196,7 @@ public class Auth extends AbstractDescribableImpl<Auth> implements Serializable 
             newAuth.setCredentials(oldAuth.getCreds());
             return newAuth;
         } else {
-            return NULL_AUTH;
+            return NullAuth.INSTANCE;
         }
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -85,6 +85,12 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
 
     private static final long serialVersionUID = -4059001060991775146L;
 
+    /**
+     * Default for this class is "no auth configured" since we do not want to override potential global config
+     */
+    private final static Auth2 DEFAULT_AUTH = NullAuth.INSTANCE;
+
+    
     private static final int      DEFAULT_POLLINTERVALL = 10;
     private static final String   paramerizedBuildUrl   = "/buildWithParameters";
     private static final String   normalBuildUrl        = "/build";
@@ -127,7 +133,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
         //migrate Auth To Auth2
         if(auth2 == null) {
             if(auth == null || auth.size() <= 0) {
-                auth2 = NullAuth.INSTANCE;
+                auth2 = DEFAULT_AUTH;
             } else {
                 auth2 = Auth.authToAuth2(auth);
             }
@@ -1338,7 +1344,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
     }
 
     public Auth2 getAuth2() {
-        return (auth2 != null) ? auth2 : NullAuth.INSTANCE;
+        return (auth2 != null) ? auth2 : DEFAULT_AUTH;
     }
 
     public boolean getShouldNotFailBuild() {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfiguration.java
@@ -119,7 +119,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
         parameterFile = "";
     }
 
-    /**
+    /*
      * see https://wiki.jenkins.io/display/JENKINS/Hint+on+retaining+backward+compatibility
      */
     @SuppressWarnings("deprecation")
@@ -127,7 +127,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
         //migrate Auth To Auth2
         if(auth2 == null) {
             if(auth == null || auth.size() <= 0) {
-                auth2 = new NullAuth();
+                auth2 = NullAuth.INSTANCE;
             } else {
                 auth2 = Auth.authToAuth2(auth);
             }
@@ -1338,7 +1338,7 @@ public class RemoteBuildConfiguration extends Builder implements SimpleBuildStep
     }
 
     public Auth2 getAuth2() {
-        return this.auth2;
+        return (auth2 != null) ? auth2 : NullAuth.INSTANCE;
     }
 
     public boolean getShouldNotFailBuild() {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -207,10 +207,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
     @Override
     public RemoteJenkinsServer clone() throws CloneNotSupportedException {
         RemoteJenkinsServer clone = (RemoteJenkinsServer)super.clone();
-        clone.address = address;
         clone.auth2 = (auth2 == null) ? null : auth2.clone();
-        clone.displayName = displayName;
-        clone.hasBuildTokenRootSupport = hasBuildTokenRootSupport;
         return clone;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -13,7 +13,6 @@ import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2.Auth2Descriptor;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.NoneAuth;
-import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.NullAuth;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -33,6 +32,11 @@ import hudson.util.FormValidation;
  */
 public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsServer> implements Cloneable {
 
+    /**
+     * Default for this class is No Authentication
+     */
+    private final static Auth2 DEFAULT_AUTH = NoneAuth.INSTANCE;
+  
     /**
      * We need to keep this for compatibility - old config deserialization!
      * @deprecated since 2.3.0-SNAPSHOT - use {@link Auth2} instead.
@@ -60,7 +64,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
         //migrate Auth To Auth2
         if(auth2 == null) {
             if(auth == null || auth.size() <= 0) {
-                auth2 = NoneAuth.INSTANCE; 
+                auth2 = DEFAULT_AUTH; 
             } else {
                 auth2 = Auth.authToAuth2(auth);
             }
@@ -85,7 +89,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
     @DataBoundSetter
     public void setAuth2(Auth2 auth2)
     {
-        this.auth2 = (auth2 != null) ? auth2 : NoneAuth.INSTANCE;
+        this.auth2 = (auth2 != null) ? auth2 : DEFAULT_AUTH;
     }
 
     @DataBoundSetter

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -37,7 +37,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
      * @deprecated since 2.3.0-SNAPSHOT - use {@link Auth2} instead.
      */
     @CheckForNull
-    private List<Auth> auth;
+    private transient List<Auth> auth;
 
     @CheckForNull
     private String     displayName;
@@ -51,6 +51,24 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
     public RemoteJenkinsServer() {
     }
 
+    /**
+     * see https://wiki.jenkins.io/display/JENKINS/Hint+on+retaining+backward+compatibility
+     */
+    @SuppressWarnings("deprecation")
+    protected Object readResolve() {
+        //migrate Auth To Auth2
+        if(auth2 == null) {
+            if(auth == null || auth.size() <= 0) {
+                auth2 = new NoneAuth(); 
+            } else {
+                auth2 = Auth.authToAuth2(auth);
+            }
+        }
+        auth = null;
+        return this;
+    }
+    
+    
     @DataBoundSetter
     public void setDisplayName(String displayName)
     {
@@ -96,23 +114,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
 
     @CheckForNull
     public Auth2 getAuth2() {
-        migrateAuthToAuth2();
         return auth2;
-    }
-
-    /**
-     * Migrates old <code>Auth</code> to <code>Auth2</code> if necessary.
-     * @deprecated since 2.3.0-SNAPSHOT - get rid once all users migrated
-     */
-    private void migrateAuthToAuth2() {
-        if(auth2 == null) {
-            if(auth == null || auth.size() <= 0) {
-                auth2 = new NoneAuth();
-            } else {
-                auth2 = Auth.authToAuth2(auth);
-            }
-        }
-        auth = null;
     }
 
     @CheckForNull

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -13,6 +13,7 @@ import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.Auth2.Auth2Descriptor;
 import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.NoneAuth;
+import org.jenkinsci.plugins.ParameterizedRemoteTrigger.auth2.NullAuth;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -51,7 +52,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
     public RemoteJenkinsServer() {
     }
 
-    /**
+    /*
      * see https://wiki.jenkins.io/display/JENKINS/Hint+on+retaining+backward+compatibility
      */
     @SuppressWarnings("deprecation")
@@ -59,7 +60,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
         //migrate Auth To Auth2
         if(auth2 == null) {
             if(auth == null || auth.size() <= 0) {
-                auth2 = new NoneAuth(); 
+                auth2 = NoneAuth.INSTANCE; 
             } else {
                 auth2 = Auth.authToAuth2(auth);
             }
@@ -84,7 +85,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
     @DataBoundSetter
     public void setAuth2(Auth2 auth2)
     {
-        this.auth2 = (auth2 != null) ? auth2 : new NoneAuth();
+        this.auth2 = (auth2 != null) ? auth2 : NoneAuth.INSTANCE;
     }
 
     @DataBoundSetter
@@ -114,7 +115,7 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
 
     @CheckForNull
     public Auth2 getAuth2() {
-        return auth2;
+        return (auth2 != null) ? auth2 : NoneAuth.INSTANCE;
     }
 
     @CheckForNull

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2.java
@@ -63,10 +63,4 @@ public abstract class Auth2 extends AbstractDescribableImpl<Auth2> implements Se
         return (Auth2)super.clone();
     };
 
-    @Override
-    public abstract int hashCode();
-
-    @Override
-    public abstract boolean equals(Object obj);
-
 }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/CredentialsAuth.java
@@ -161,15 +161,6 @@ public class CredentialsAuth extends Auth2 {
         }
     }
 
-
-
-    @Override
-    public CredentialsAuth clone() throws CloneNotSupportedException {
-        CredentialsAuth clone = (CredentialsAuth)super.clone();
-        clone.credentials = credentials;
-        return clone;
-    }
-
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NoneAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NoneAuth.java
@@ -56,11 +56,6 @@ public class NoneAuth extends Auth2 {
     }
 
     @Override
-    public NoneAuth clone() throws CloneNotSupportedException {
-        return (NoneAuth)super.clone();
-    }
-
-    @Override
     public int hashCode() {
         return "NoneAuth".hashCode();
     }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NoneAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NoneAuth.java
@@ -18,6 +18,9 @@ public class NoneAuth extends Auth2 {
     @Extension
     public static final Auth2Descriptor DESCRIPTOR = new NoneAuthDescriptor();
 
+    public static final NoneAuth INSTANCE = new NoneAuth();
+    
+
     @DataBoundConstructor
     public NoneAuth() {
     }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
@@ -18,10 +18,13 @@ public class NullAuth extends Auth2 {
     @Extension
     public static final Auth2Descriptor DESCRIPTOR = new NullAuthDescriptor();
 
+    public static final NullAuth INSTANCE = new NullAuth();
+
+
     @DataBoundConstructor
     public NullAuth() {
     }
-
+    
     @Override
     public void setAuthorizationHeader(URLConnection connection, BuildContext context) throws IOException {
         //Ignore
@@ -49,7 +52,6 @@ public class NullAuth extends Auth2 {
             return "Don't Set/Override";
         }
     }
-
 
     @Override
     public NullAuth clone() throws CloneNotSupportedException {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
@@ -54,11 +54,6 @@ public class NullAuth extends Auth2 {
     }
 
     @Override
-    public NullAuth clone() throws CloneNotSupportedException {
-        return (NullAuth)super.clone();
-    }
-
-    @Override
     public int hashCode() {
         return "NullAuth".hashCode();
     }

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/NullAuth.java
@@ -20,11 +20,10 @@ public class NullAuth extends Auth2 {
 
     public static final NullAuth INSTANCE = new NullAuth();
 
-
     @DataBoundConstructor
     public NullAuth() {
     }
-    
+
     @Override
     public void setAuthorizationHeader(URLConnection connection, BuildContext context) throws IOException {
         //Ignore

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/TokenAuth.java
@@ -78,14 +78,6 @@ public class TokenAuth extends Auth2 {
     }
 
     @Override
-    public TokenAuth clone() throws CloneNotSupportedException {
-        TokenAuth clone = (TokenAuth)super.clone();
-        clone.apiToken = apiToken;
-        clone.userName = userName;
-        return clone;
-    }
-
-    @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
@@ -106,13 +98,15 @@ public class TokenAuth extends Auth2 {
         if (apiToken == null) {
             if (other.apiToken != null)
                 return false;
-        } else if (!apiToken.equals(other.apiToken))
+        } else if (!apiToken.equals(other.apiToken)) {
             return false;
+        }
         if (userName == null) {
             if (other.userName != null)
                 return false;
-        } else if (!userName.equals(other.userName))
+        } else if (!userName.equals(other.userName)) {
             return false;
+        }
         return true;
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
@@ -77,7 +77,6 @@ public class RemoteBuildConfigurationTest {
       RemoteBuildConfiguration config = new RemoteBuildConfiguration();
       config.setJob("job");
 
-      assertEquals(1, config.getAuth().size());
       assertEquals(false, config.getBlockBuildUntilComplete()); //False in Job
       assertEquals(false, config.getEnhancedLogging());
       assertEquals("job", config.getJob());

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2Test.java
@@ -43,14 +43,14 @@ public class Auth2Test {
 
     @Test
     public void testNullAuthCloneBehaviour() throws CloneNotSupportedException {
-        NullAuth original = new NullAuth();
+        NullAuth original = NullAuth.INSTANCE;
         NullAuth clone = original.clone();
         verifyEqualsHashCode(original, clone);
     }
 
     @Test
     public void testNoneAuthCloneBehaviour() throws CloneNotSupportedException {
-        NoneAuth original = new NoneAuth();
+        NoneAuth original = NoneAuth.INSTANCE;
         NoneAuth clone = original.clone();
         verifyEqualsHashCode(original, clone);
     }

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2Test.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/auth2/Auth2Test.java
@@ -13,7 +13,7 @@ public class Auth2Test {
     public void testCredentialsAuthCloneBehaviour() throws CloneNotSupportedException {
         CredentialsAuth original = new CredentialsAuth();
         original.setCredentials("original");
-        CredentialsAuth clone = original.clone();
+        CredentialsAuth clone = (CredentialsAuth)original.clone();
         verifyEqualsHashCode(original, clone);
 
         //Test changing clone
@@ -28,7 +28,7 @@ public class Auth2Test {
         TokenAuth original = new TokenAuth();
         original.setApiToken("original");
         original.setUserName("original");
-        TokenAuth clone = original.clone();
+        TokenAuth clone = (TokenAuth)original.clone();
         verifyEqualsHashCode(original, clone);
 
         //Test changing clone
@@ -44,14 +44,14 @@ public class Auth2Test {
     @Test
     public void testNullAuthCloneBehaviour() throws CloneNotSupportedException {
         NullAuth original = NullAuth.INSTANCE;
-        NullAuth clone = original.clone();
+        NullAuth clone = (NullAuth)original.clone();
         verifyEqualsHashCode(original, clone);
     }
 
     @Test
     public void testNoneAuthCloneBehaviour() throws CloneNotSupportedException {
         NoneAuth original = NoneAuth.INSTANCE;
-        NoneAuth clone = original.clone();
+        NoneAuth clone = (NoneAuth)original.clone();
         verifyEqualsHashCode(original, clone);
     }
 


### PR DESCRIPTION
(+ stop setting defaults in constructor)

see https://github.com/jenkinsci/parameterized-remote-trigger-plugin/pull/32#discussion_r172030254
(and https://github.com/jenkinsci/parameterized-remote-trigger-plugin/pull/32#discussion_r172030204)

@marcusholl @alejandraferreirovidal 