### PR TITLE
review remote address

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServer.java
@@ -135,24 +135,6 @@ public class RemoteJenkinsServer extends AbstractDescribableImpl<RemoteJenkinsSe
         return (DescriptorImpl) super.getDescriptor();
     }
 
-    /**
-     * @return the remote server address
-     * @throws RuntimeException
-     *             if the address of the remote server was not set
-     */
-    @Nonnull
-    public String getRemoteAddress() {
-        if (address == null) {
-            throw new RuntimeException("The remote address can not be empty.");
-        } else {
-            try {
-                new URL(address);
-            } catch (MalformedURLException e) {
-                throw new RuntimeException("Malformed address (" + address + "). Remember to indicate the protocol, i.e. http, https, etc.");
-            }
-        }
-        return address;
-    }
 
     @Extension
     public static class DescriptorImpl extends Descriptor<RemoteJenkinsServer> {

--- a/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/Handle.java
+++ b/src/main/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/pipeline/Handle.java
@@ -335,7 +335,7 @@ public class Handle implements Serializable {
     public String toString() {
 
         StringBuilder sb = new StringBuilder();
-        sb.append(String.format("Handle [job=%s, remoteServerURL=%s, queueId=%s", remoteBuildConfiguration.getJob(), effectiveRemoteServer.getRemoteAddress(), queueId));
+        sb.append(String.format("Handle [job=%s, remoteServerURL=%s, queueId=%s", remoteBuildConfiguration.getJob(), effectiveRemoteServer.getAddress(), queueId));
         if(buildStatus != null) sb.append(String.format(", buildStatus=%s", buildStatus));
         if(buildData != null) sb.append(String.format(", buildNumber=%s, buildUrl=%s", buildData.getBuildNumber(), buildData.getURL()));
         sb.append("]");

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteBuildConfigurationTest.java
@@ -193,7 +193,7 @@ public class RemoteBuildConfigurationTest {
         config.setJob("MyJob");
         config.setRemoteJenkinsUrl("http://test:8080");
         assertEquals("MyJob", config.getJob());
-        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
     }
 
     @Test @WithoutJenkins
@@ -204,7 +204,7 @@ public class RemoteBuildConfigurationTest {
 
         config.setRemoteJenkinsName("remoteJenkinsName");
         assertEquals("MyJob", config.getJob());
-        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
     }
 
     @Test @WithoutJenkins
@@ -215,7 +215,7 @@ public class RemoteBuildConfigurationTest {
 
         config.setRemoteJenkinsName("remoteJenkinsName");
         assertEquals("A/B/C/D/MyJob", config.getJob());
-        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
     }
 
     @Test @WithoutJenkins
@@ -223,7 +223,7 @@ public class RemoteBuildConfigurationTest {
         RemoteBuildConfiguration config = new RemoteBuildConfiguration();
         config.setJob("http://test:8080/job/folder/job/MyJob");
         assertEquals("http://test:8080/job/folder/job/MyJob", config.getJob()); //The value configured for "job"
-        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://test:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
     }
 
     @Test @WithoutJenkins
@@ -233,7 +233,7 @@ public class RemoteBuildConfigurationTest {
         config.setJob("http://testA:8080/job/folder/job/MyJobA");
         config.setRemoteJenkinsUrl("http://testB:8080");
         assertEquals("http://testA:8080/job/folder/job/MyJobA", config.getJob()); //The value configured for "job"
-        assertEquals("http://testA:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://testA:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
     }
 
     @Test @WithoutJenkins
@@ -245,7 +245,7 @@ public class RemoteBuildConfigurationTest {
 
         config.setRemoteJenkinsName("remoteJenkinsName");
         assertEquals("http://testA:8080/job/folder/job/MyJobA", config.getJob()); //The value configured for "job"
-        assertEquals("http://testA:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://testA:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
     }
 
     @Test @WithoutJenkins
@@ -270,12 +270,12 @@ public class RemoteBuildConfigurationTest {
         config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://globallyConfigured:8080");
 
         config.setRemoteJenkinsName("remoteJenkinsName");
-        assertEquals("http://globallyConfigured:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://globallyConfigured:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
 
         //Now override remote host URL
         config.setRemoteJenkinsUrl("http://locallyOverridden:8080");
         assertEquals("MyJob", config.getJob());
-        assertEquals("http://locallyOverridden:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://locallyOverridden:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
     }
 
     @Test @WithoutJenkins
@@ -312,7 +312,7 @@ public class RemoteBuildConfigurationTest {
 
         config.setRemoteJenkinsName("notConfiguredRemoteHost");
         config.setRemoteJenkinsUrl("http://locallyOverridden:8080");
-        assertEquals("http://locallyOverridden:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://locallyOverridden:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
     }
 
     @Test @WithoutJenkins
@@ -322,7 +322,7 @@ public class RemoteBuildConfigurationTest {
         config = mockGlobalRemoteHost(config, "remoteJenkinsName", "http://globallyConfigured:8080");
 
         config.setRemoteJenkinsName("notConfiguredRemoteHost");
-        assertEquals("http://localJobUrl:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://localJobUrl:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
     }
 
     @Test @WithoutJenkins
@@ -330,7 +330,7 @@ public class RemoteBuildConfigurationTest {
         RemoteBuildConfiguration config = new RemoteBuildConfiguration();
         config.setJob("MyJob");
         config.setRemoteJenkinsUrl("http://hostname:8080");
-        assertEquals("http://hostname:8080", config.evaluateEffectiveRemoteHost(null).getRemoteAddress());
+        assertEquals("http://hostname:8080", config.evaluateEffectiveRemoteHost(null).getAddress());
     }
 
     @Test @WithoutJenkins
@@ -384,7 +384,7 @@ public class RemoteBuildConfigurationTest {
     }
 
     @Test @WithoutJenkins
-    public void testGenerateJobUrl() throws MalformedURLException {
+    public void testGenerateJobUrl() throws MalformedURLException, AbortException {
         RemoteJenkinsServer remoteServer = new RemoteJenkinsServer();
         remoteServer.setAddress("https://server:8080/jenkins");
 
@@ -411,8 +411,8 @@ public class RemoteBuildConfigurationTest {
         try {
             RemoteJenkinsServer missingUrl = new RemoteJenkinsServer();
             RemoteBuildConfiguration.generateJobUrl(missingUrl, "JobName");
-            Assert.fail("Expected RuntimeException");
-        } catch(RuntimeException e) {}
+            Assert.fail("Expected AbortException");
+        } catch(AbortException e) {}
 
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServerTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ParameterizedRemoteTrigger/RemoteJenkinsServerTest.java
@@ -37,8 +37,6 @@ public class RemoteJenkinsServerTest {
         verifyEqualsHashCode(server, clone);
         assertEquals("address", ADDRESS, clone.getAddress());
         assertEquals("address", server.getAddress(), clone.getAddress());
-        assertEquals("remoteAddress", ADDRESS, clone.getRemoteAddress());
-        assertEquals("remoteAddress", server.getRemoteAddress(), clone.getRemoteAddress());
         assertEquals("auth2", server.getAuth2(), clone.getAuth2());
         assertEquals("displayName", DISPLAY_NAME, clone.getDisplayName());
         assertEquals("displayName", server.getDisplayName(), clone.getDisplayName());


### PR DESCRIPTION
- https://github.com/jenkinsci/parameterized-remote-trigger-plugin/pull/32#discussion_r172030326
Better to introduce separate methods for getting strings and URLs. Checking correctness in string getter is not required in general


- https://github.com/jenkinsci/parameterized-remote-trigger-plugin/pull/32#discussion_r172030309
In your case it will be empty if the class is restored from the disk after the migration